### PR TITLE
Add recent studies to validation section of references

### DIFF
--- a/documentation/references/validation/readme.md
+++ b/documentation/references/validation/readme.md
@@ -4,3 +4,8 @@ E.O. Kung, A.L. Les, C.A. Figueroa, F. Medina, K. Arcaute, R.B. Wicker, M.V. McC
 
 E.O. Kung, A.M. Kahn, J.C. Burns and A.L. Marsden, **In-vitro validation of patient-specific hemodynamic simulations in coronary aneurysms caused by Kawasaki disease**, _Cardiovascular Engineering and Technology_, 5(2):189-201, 2014. [Link](http://link.springer.com/article/10.1007/s13239-014-0184-8#page-1)
 
+I.S. Lan, J. Liu, W. Yang, J. Zimmermann, D.B. Ennis and A.L. Marsden, **Validation of the Reduced Unified Continuum Formulation Against In Vitro 4D-Flow MRI**, _Annals of Biomedical Engineering_, 51(2):377-393, 2023. [Link](https://pmc.ncbi.nlm.nih.gov/articles/PMC11402517/)
+
+J. Zimmermann, K. Bäumler, M. Loecher, T.E. Cork, A.L. Marsden, D.B. Ennis and D. Fleischmann, **Hemodynamic effects of entry and exit tear size in aortic dissection evaluated with in vitro magnetic resonance imaging and fluid-structure interaction simulation**, _Scientific Reports_, 13(1):22557, 2023. [Link](https://www.nature.com/articles/s41598-023-49942-0)
+
+P.J. Nair, M.R. Pfaller, S.A. Dual, D.B. McElhinney, D.B. Ennis and A.L. Marsden, **Non-invasive Estimation of Pressure Drop Across Aortic Coarctations: Validation of 0D and 3D Computational Models with In Vivo Measurements**, _Annals of Biomedical Engineering_, 52(5):1335-1346, 2024. [Link](https://link.springer.com/article/10.1007/s10439-024-03457-5)


### PR DESCRIPTION
This adds the requested recent studies to the validation section of the references page of the SimVascular website.

Closes https://github.com/SimVascular/simvascular.github.io/issues/93