### PR TITLE
Replace svSolver link with svMorph

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,12 +255,12 @@
           </div>
           <div class="col-lg-4 col-md-6 col-12">
             <div class="applicationsHeader">
-              <h2><a href="https://github.com/SimVascular/svSolver" target="_blank" class="application-link">svSolver</a></h2>
+              <h2><a href="https://github.com/SimVascular/svMorph" target="_blank" class="application-link">svMorph</a></h2>
             </div>
             <div class="applicationsText">
-              <p>A parallel computational fluid dynamics (CFD) finite element
-                solver incorporating boundary conditions useful for blood flow
-                simulations</p>
+              <p>A real-time interactive tool for performing morphological
+                edits on vascular surface meshes, including aneurysm,
+                stenosis, and stenting</p>
             </div>
           </div>
           <div class="col-lg-4 col-md-6 col-12">


### PR DESCRIPTION
This replaces svSolver with svMorph in the Suite of Applications section of the main page of the SimVascular website.

Closes https://github.com/SimVascular/simvascular.github.io/issues/86