### PR TITLE
Document multiple CEP stimuli

### DIFF
--- a/documentation/multi_physics/solver-input-file/domain_parameters/readme.md
+++ b/documentation/multi_physics/solver-input-file/domain_parameters/readme.md
@@ -17,7 +17,7 @@ The <i>Domain Subsection</i> is organized as follows
 <br>
 &lt;<strong>Viscosity</strong>&gt;
 <br><br>
-&lt;<strong>Stimulus</strong> type=<i>stimulus_type</i>&gt;<br>
+&lt;<strong>Stimulus</strong> type=<i>stimulus_type</i>&gt; <i>(repeatable)</i><br>
 [<a href="#domain_Stimulus_subsection"> Stimulus Subsection </a> ]
 <br>
 &lt;<strong>Stimulus</strong>&gt;
@@ -419,17 +419,24 @@ The <strong>Stimulus</strong> keyword adds stimulus settings to the enclosing do
   <li> "Istim" - the applied stimulus is a source current and not a voltage source </li>
 </ul>
 
+Multiple <strong>&lt;Stimulus&gt;</strong> elements may be placed within the same explicit
+<strong>&lt;Domain&gt;</strong> subsection, or under the equation-level default domain when no
+explicit domain subsection is used. Each stimulus is evaluated independently using its own
+amplitude, timing parameters, and optional spatial bounds. When multiple stimuli are active at
+the same node and time, their amplitudes are summed. Defining no <strong>&lt;Stimulus&gt;</strong>
+elements produces no applied stimulus; defining one applies only that stimulus.
+
 <h5 id="stimulus_parameters"> Parameters </h5>
 <div class="bc_param_div">
 <strong>&lt;Amplitude&gt;</strong> <i>real</i> [0.0] <nobr>
 <strong>&lt;/Amplitude&gt;</strong>
 </nobr><br>
-The stimulus amplitude.
+The stimulus amplitude. An omitted or zero-valued amplitude contributes no stimulus.
 <br>
-<strong>&lt;Cycle_length&gt;</strong> <i>real</i> [0.0] <nobr>
+<strong>&lt;Cycle_length&gt;</strong> <i>real</i> [total simulation duration] <nobr>
 <strong>&lt;/Cycle_length&gt;</strong>
 </nobr><br>
-The stimulus cycle length. 
+The stimulus cycle length. When omitted, the total simulation duration is used. For a stimulus with a nonzero amplitude, the cycle length must be greater than zero.
 <br>
 <strong>&lt;Duration&gt;</strong> <i>real</i> [0.0] <nobr>
 <strong>&lt;/Duration&gt;</strong>


### PR DESCRIPTION
## Current situation

The CEP stimulus documentation currently presents a single `<Stimulus>` element and does not describe the multiple-stimulus capability added in SimVascular/svMultiPhysics#586.

This PR updates the documentation to describe repeated `<Stimulus>` elements within the same domain, independent stimulus evaluation, additive behavior for overlapping active stimuli, and the relevant default behavior.

Closes #101

## Release Notes

- Document repeated CEP `<Stimulus>` elements within one domain.
- Document independent timing, amplitude, and spatial bounds for each stimulus.
- Document summation when multiple stimuli are active at the same node and time.
- Clarify zero-, one-, and multiple-stimulus behavior.
- Clarify amplitude and cycle-length defaults.

## Documentation

Updated:

`documentation/multi_physics/solver-input-file/domain_parameters/readme.md`

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
